### PR TITLE
Fix `‘unique_ptr’ was not declared in this scope`

### DIFF
--- a/EasyBMP.h
+++ b/EasyBMP.h
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <cctype>
 #include <cstring>
+#include <memory>
 
 #ifndef EasyBMP
 #define EasyBMP


### PR DESCRIPTION
When compiling EasyBMP, the following error is thrown on line 771 of `EasyBMP.cpp`:

`error: ‘unique_ptr’ was not declared in this scope`

For reference, here is line 771:

```cpp
unique_ptr<ebmpBYTE> Buffer(new ebmpBYTE[BufferSize]);
```

This error is thrown because `<memory>` is not included in `EasyBMP.h`, as explained in #1, so we can't use `std::unique_ptr`. This pull request fixes that issue by including `<memory>` in `EasyBMP.h`.